### PR TITLE
Add support for running tests in jsdom

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var addDefaultLoggingAndName = require('./lib/default-logging');
 var chromedriver = require('./lib/chromedriver');
 var publishCode = require('./lib/publish-code');
+var runJsdom = null
 var runChromedriver = require('./lib/run-chromedriver');
 var runSauceLabs = require('./lib/run-sauce-labs');
 var runBrowsers = require('./lib/run-browsers');
@@ -24,7 +25,21 @@ function runTests(entries, remote, options) {
     disableSSL: options.disableSSL
   }).then(function (location) {
     options.onPublish(location.url);
-    if (remote === 'chromedriver') {
+    if (remote === 'jsdom') {
+      if (!runJsdom) runJsdom = require('./lib/run-jsdom');
+      return runJsdom(location, remote, {
+        name: options.name,
+        throttle: options.throttle,
+        debug: options.debug,
+        allowExceptions: options.allowExceptions,
+        testComplete: options.testComplete,
+        testPassed: options.testPassed,
+        timeout: options.timeout
+      }).then(function (result) {
+        options.onAllResults(result);
+        return result;
+      });
+    } else if (remote === 'chromedriver') {
       return runChromedriver(location, remote, {
         name: options.name,
         throttle: options.throttle,

--- a/lib/run-chromedriver.js
+++ b/lib/run-chromedriver.js
@@ -8,6 +8,7 @@ module.exports = runChromedriver;
 /**
  * Run a test using chromedriver, then stops chrome driver and returns the result
  *
+ * @option {String}          name
  * @option {Function}        throttle
  * @option {Object}          platform|capabilities
  * @option {Boolean}         debug

--- a/lib/run-jsdom.js
+++ b/lib/run-jsdom.js
@@ -1,0 +1,88 @@
+'use strict';
+
+var assert = require('assert');
+var Promise = require('promise');
+var jsdom = require('jsdom');
+var runDriver = require('./run-driver');
+
+module.exports = runJsdom;
+/**
+ * Run a test using chromedriver, then stops chrome driver and returns the result
+ *
+ * @option {String}          name
+ * @option {Function}        throttle
+ * @option {Boolean}         debug
+ * @option {Boolean}         allowExceptions
+ * @option {String|Function} testComplete
+ * @option {String|Function} testPassed
+ * @option {String}          timeout
+ *
+ * Returns:
+ *
+ * ```js
+ * { "passed": true, "duration": "3000" }
+ * ```
+ *
+ * @param {Location} location
+ * @param {Object}   remote
+ * @param {Object}   platform
+ * @param {Options}  options
+ * @returns {Promise}
+ */
+function runJsdom(location, remote, options) {
+  assert(remote === 'jsdom', 'expected remote to be jsdom');
+  var throttle = options.throttle || function (fn) { return fn(); };
+  return throttle(function () {
+    return new Promise(function (resolve, reject) {
+      jsdom.env(location.url, {
+        virtualConsole: options.debug ? jsdom.createVirtualConsole().sendTo(console) : false,
+        features: {
+          FetchExternalResources: ["script", "img", "css", "frame", "iframe", "link"],
+          ProcessExternalResources: ["script"]
+        }
+      }, function (errors, window) {
+        if (errors) return reject(errors[0]);
+        else resolve(window);
+      });
+    }).then(function (window) {
+      var driver = {
+        sauceJobUpdate: function () {
+          return Promise.resolve(null);
+        },
+        browser: function () {
+          return {
+            activeWindow: function () {
+              return {
+                navigator: function () {
+                  return {
+                    navigateTo: function (url) {
+                      return Promise.resolve(null).then(function () {
+                        assert(url === location.url, 'jsdom does not support navigation');
+                      });
+                  };
+                },
+                execute: function (str) {
+                  return (new Promise(function (resolve) { setTimeout(resolve, 100); })).then(function () {
+                    return window.Function('', str)();
+                  });
+                }
+              };
+            }
+          };
+        },
+        dispose: function () {
+          return Promise.resolve(null).then(function () {
+            window.close();
+          });
+        }
+      };
+      return runDriver(location, driver, {
+        name: options.name,
+        allowExceptions: options.allowExceptions,
+        testComplete: options.testComplete,
+        testPassed: options.testPassed,
+        timeout: options.timeout
+      });
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "then-request": "^2.1.0",
     "throat": "^1.0.0"
   },
+  "optionalDependencies": {
+    "jsdom": "^5.6.1"
+  },
   "devDependencies": {},
   "scripts": {
     "test": "node test"

--- a/test.js
+++ b/test.js
@@ -7,6 +7,15 @@ var run = require('./');
 var USER = 'then-jsonp';
 var ACCESS_KEY = 'beb60500-a585-440c-82e9-0888d716570d';
 
+run(__dirname + '/empty.js', 'jsdom', {
+  name: 'local-tests',
+  testComplete: 'return true;',
+  testPassed: 'return true;'
+}).done(function (result) {
+  assert(result.passed === true);
+  console.dir(result);
+});
+
 run(__dirname + '/empty.js', 'chromedriver', {
   name: 'local-tests',
   testComplete: 'return true;',


### PR DESCRIPTION
jsdom is way way faster than chrome for running quick tests.  It can also be easily used in travis, so would be ideal as a smoke test before running the slow tests on sauce labs.
